### PR TITLE
Updated tape to version 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel": "5.8.23",
     "faucet": "0.0.1",
     "glob": "5.0.15",
-    "tape": "4.2.0",
+    "tape": "4.2.1",
     "typescript": "1.6.2"
   },
   "dependencies": {


### PR DESCRIPTION
:rocket:

tape just published version 4.2.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 7 commits (ahead by 7, behind by 0).

- [0dc9313](https://github.com/substack/tape/commit/0dc93136f0e6e1ae83a9cb5e1117b72028fd9d47): v4.2.1
- [77e1848](https://github.com/substack/tape/commit/77e184843f955722e261f81e50c5cc10f06784fd): Use `string.prototype.trim` instead of relying on `String#trim`, for ES3.
- [1e22819](https://github.com/substack/tape/commit/1e22819419ca4230e9a86e0405f51cee17c99972): Merge pull request #195 from wbinnssmith/patch-1
- [df62458](https://github.com/substack/tape/commit/df624584d8420848bfcb340a62701dcd717867af): Add Node v4
- [0e407f0](https://github.com/substack/tape/commit/0e407f05d66c6e29ef26989d659db99b86b40a64): Bumping `defined` to v1.0.0 - no implementation change, just follows semver now.
- [4711573](https://github.com/substack/tape/commit/47115739d4fb7360891c807335cc1ffbf2a2a0d6): Merge pull request #189 from gritzko/master
- [c22ad78](https://github.com/substack/tape/commit/c22ad7857655b779fdab6002a0b4902e4e130d9b): add tape-dom link to the readme

See the [full diff](https://github.com/substack/tape/compare/aadcf4a95ed6810fa404dbe01f3b745252d4f12e...0dc93136f0e6e1ae83a9cb5e1117b72028fd9d47).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>